### PR TITLE
Use new joint handles

### DIFF
--- a/fake_joint_driver/include/fake_joint_driver/fake_joint_driver.h
+++ b/fake_joint_driver/include/fake_joint_driver/fake_joint_driver.h
@@ -9,15 +9,12 @@
  */
 #include <rclcpp/rclcpp.hpp>
 
-#include <hardware_interface/joint_command_handle.hpp>
-#include <hardware_interface/joint_state_handle.hpp>
+#include <hardware_interface/joint_handle.hpp>
 #include <hardware_interface/robot_hardware.hpp>
 
 class FakeJointDriver : public hardware_interface::RobotHardware
 {
 private:
-  std::vector<hardware_interface::JointStateHandle> joint_state_handles_;
-  std::vector<hardware_interface::JointCommandHandle> joint_command_handles_;
   std::vector<hardware_interface::OperationModeHandle> joint_mode_handles_;
 
   std::vector<double> cmd_dis;


### PR DESCRIPTION
The intention of this PR is to fix an issue https://github.com/ros-planning/moveit2/issues/283.

Recent `ros2_control` update has removed `JointStateHandle` and `JointCommandHandle` and has added `JointHandle`. (See https://github.com/ros-controls/ros2_control/issues/124)

The code of this PR refers [test_robot_hardware of ros2_control](https://github.com/ros-controls/ros2_control/blob/9a25721bbec2e8db9410163a7d50160ded0d72c1/test_robot_hardware/src/test_robot_hardware.cpp).